### PR TITLE
Add rename_profile.py utility for changing browser profile names

### DIFF
--- a/rename_profile.py
+++ b/rename_profile.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
 
 import os
-import json
 import sys
-from lib.chromium import get_chromium_profiles_path
+import json
+from lib.chromium import get_chromium_profiles
 from lib.helpers import get_browsers
 
 
 def get_profile_path(browser_name, profile_folder):
-    """Get the path to the profile's Preferences file"""
+    """Get the path to the profile's Preferences file
+
+    Args:
+        browser_name (str): The name of the browser (e.g., "chromium").
+        profile_folder (str): The name of the profile folder.
+    Returns:
+        str: The path to the profile's Preferences file.
+    """
     home = os.path.expanduser("~")
     supported_browsers = get_browsers()
 
@@ -18,31 +25,39 @@ def get_profile_path(browser_name, profile_folder):
         if b["name"] == browser_name:
             browser = b
             break
-
     if not browser:
-        print(f"Browser '{browser_name}' not found")
         return None
 
     # Get the profile file path
     path_profile = f"{home}/{browser['path']}"
-    profiles = get_chromium_profiles_path(browser, path_profile)
 
-    # Find the profile folder in the list of profile paths
+    # Get the list of profiles
+    profiles = get_chromium_profiles(browser, path_profile)
+    if not profiles:
+        return None
+
+    # Find profile file
     profile_file = None
+    target_arg = f"{browser_name} {profile_folder}"
     for p in profiles:
-        if f"/{profile_folder}/" in p:
-            profile_file = p
+        if p.get("arg") == target_arg:
+            profile_dir = p.get("arg").replace(f"{browser_name} ", "")
+            profile_file = os.path.join(path_profile, profile_dir, "Preferences")
             break
-
     if not profile_file:
-        print(f"Profile folder '{profile_folder}' not found")
         return None
 
     return profile_file
 
 
 def rename_profile(profile_file, new_name=None):
-    """Rename the profile directly"""
+    """Rename the profile directly
+    Args:
+        profile_file (str): The path to the profile file.
+        new_name (str): The new name for the profile.
+    Returns:
+        bool: True if the profile was renamed successfully, False otherwise.
+    """
     try:
         # Read the current profile data
         with open(profile_file) as f:
@@ -50,19 +65,7 @@ def rename_profile(profile_file, new_name=None):
 
         # Extract current profile name
         current_name = data.get("profile", {}).get("name", "Unknown")
-        browser_info = os.path.basename(os.path.dirname(profile_file))
-
-        # Display info about the profile
-        print(f"\nBrowser Profile: {browser_info}")
-        print(f'Current profile name: "{current_name}"')
-
-        # If no new name was provided, show instructions and exit
-        if not new_name:
-            print("\nTo rename this profile, provide a new name as an argument:")
-            print(
-                f"./main.py | jq -r '.items[1].arg' | ./rename_profile.py \"新しいプロファイル名\""
-            )
-            return False
+        # browser_info = os.path.basename(os.path.dirname(profile_file))
 
         # Update the profile name
         data["profile"]["name"] = new_name
@@ -80,35 +83,30 @@ def rename_profile(profile_file, new_name=None):
 
 
 def main():
-    # Get new profile name from command line argument
-    new_name = None
-    if len(sys.argv) > 1:
-        new_name = sys.argv[1]
+    # Split the command line arguments
+    print("sys.argv:", sys.argv, file=sys.stderr, flush=True)  # debug
+    if len(sys.argv) < 3:
+        print("Usage: rename_profile.py <new_name> <browser_and_profile>")
+        sys.exit(1)
 
-    # Get the browser and profile info from input string
-    input_string = sys.stdin.read().strip()
-
-    # Split the input into browser name and profile folder
+    new_name = sys.argv[1]
+    input_string = sys.argv[2]
     parts = input_string.split()
     if len(parts) < 2:
         print(f"Invalid input format: '{input_string}'")
         print("Expected format: 'BROWSER PROFILE'")
         sys.exit(1)
 
+    # Get the browser name and profile file
     browser_name = parts[0]
-    # The profile folder might contain spaces, so join the rest of the parts
     profile_folder = " ".join(parts[1:])
-
-    # Get the profile file path
     profile_file = get_profile_path(browser_name, profile_folder)
-
     if not profile_file:
         sys.exit(1)
 
-    # Rename the profile
+    # Check success of renaming the profile
     if not rename_profile(profile_file, new_name):
         sys.exit(1)
-
     print("Profile renamed successfully.")
 
 

--- a/rename_profile.py
+++ b/rename_profile.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import sys
+from lib.chromium import get_chromium_profiles_path
+from lib.helpers import get_browsers
+
+
+def get_profile_path(browser_name, profile_folder):
+    """Get the path to the profile's Preferences file"""
+    home = os.path.expanduser("~")
+    supported_browsers = get_browsers()
+
+    # Find the browser by name
+    browser = None
+    for b in supported_browsers.get("chromium", []):
+        if b["name"] == browser_name:
+            browser = b
+            break
+
+    if not browser:
+        print(f"Browser '{browser_name}' not found")
+        return None
+
+    # Get the profile file path
+    path_profile = f"{home}/{browser['path']}"
+    profiles = get_chromium_profiles_path(browser, path_profile)
+
+    # Find the profile folder in the list of profile paths
+    profile_file = None
+    for p in profiles:
+        if f"/{profile_folder}/" in p:
+            profile_file = p
+            break
+
+    if not profile_file:
+        print(f"Profile folder '{profile_folder}' not found")
+        return None
+
+    return profile_file
+
+
+def rename_profile(profile_file, new_name=None):
+    """Rename the profile directly"""
+    try:
+        # Read the current profile data
+        with open(profile_file) as f:
+            data = json.load(f)
+
+        # Extract current profile name
+        current_name = data.get("profile", {}).get("name", "Unknown")
+        browser_info = os.path.basename(os.path.dirname(profile_file))
+
+        # Display info about the profile
+        print(f"\nBrowser Profile: {browser_info}")
+        print(f'Current profile name: "{current_name}"')
+
+        # If no new name was provided, show instructions and exit
+        if not new_name:
+            print("\nTo rename this profile, provide a new name as an argument:")
+            print(
+                f"./main.py | jq -r '.items[1].arg' | ./rename_profile.py \"新しいプロファイル名\""
+            )
+            return False
+
+        # Update the profile name
+        data["profile"]["name"] = new_name
+
+        # Write back to file
+        with open(profile_file, "w") as f:
+            json.dump(data, f)
+
+        print(f'Profile name changed from "{current_name}" to "{new_name}"')
+        return True
+
+    except Exception as e:
+        print(f"Error renaming profile: {e}")
+        return False
+
+
+def main():
+    # Get new profile name from command line argument
+    new_name = None
+    if len(sys.argv) > 1:
+        new_name = sys.argv[1]
+
+    # Get the browser and profile info from input string
+    input_string = sys.stdin.read().strip()
+
+    # Split the input into browser name and profile folder
+    parts = input_string.split()
+    if len(parts) < 2:
+        print(f"Invalid input format: '{input_string}'")
+        print("Expected format: 'BROWSER PROFILE'")
+        sys.exit(1)
+
+    browser_name = parts[0]
+    # The profile folder might contain spaces, so join the rest of the parts
+    profile_folder = " ".join(parts[1:])
+
+    # Get the profile file path
+    profile_file = get_profile_path(browser_name, profile_folder)
+
+    if not profile_file:
+        sys.exit(1)
+
+    # Rename the profile
+    if not rename_profile(profile_file, new_name):
+        sys.exit(1)
+
+    print("Profile renamed successfully.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Profile Rename Feature for Browser Profiles Alfred Workflow

## Summary
- Feature to rename browser profiles directly from Alfred workflow
- User-friendly implementation that works entirely through UI without command line operations

## Features
- Rename browser profiles directly from Alfred with a keyboard modifier
- Simple dialog-based interface for entering new names

## Implementation
- Added new `rename_profile.py` script that:
  - Accepts browser/profile information via stdin
  - Updates the profile name in browser preference files

## How to Use
1. Open Alfred and type `bp` to show browser profiles
2. Hold Command(⌘) key while selecting a profile to rename it
3. Enter new profile name in the dialog
4. Profile name will be updated immediately
**Note:** The workflow requires configuration to add a Command(⌘) key modifier action in Alfred. This is not automatically included in the script and needs to be manually set up in the workflow editor.

## Technical Details
- The script parses the input from Alfred in `BROWSER PROFILE` format
- It locates the appropriate Preferences file in the browser's profile directory
- Updates the `profile.name` field in the JSON data

## Testing
Tested with multiple profiles in Google Chrome