### PR TITLE
Fix Chromium profile names showing as "Your Chrome"

### DIFF
--- a/lib/chromium.py
+++ b/lib/chromium.py
@@ -15,22 +15,34 @@ def get_chromium_profiles(browser, path):
     if os.path.isdir(path) == False:
         return profiles
 
+    # Read profile names from Local State (per-profile Preferences often just says "Your Chrome")
+    info_cache = {}
+    local_state_file = os.path.join(path, "Local State")
+    if os.path.isfile(local_state_file):
+        with open(local_state_file) as f:
+            local_state = json.load(f)
+            info_cache = local_state.get("profile", {}).get("info_cache", {})
+
     folders = [name for name in os.listdir(path) if os.path.isdir(os.path.join(path, name))]
 
     for folder in folders:
         file = "{}/{}/Preferences".format(path, folder)
         if folder != 'System Profile' and os.path.isfile(file):
-            with open(file) as f:
-                data = json.load(f)
-                browser_profile = data['profile']['name']
+            cached = info_cache.get(folder, {})
+            browser_profile = (
+                cached.get("name")
+                or cached.get("shortcut_name")
+                or cached.get("gaia_name")
+                or folder
+            )
 
-                profiles.append({
-                    "icon": {
-                        "path": "icons/{}".format(icon)
-                    },
-                    "arg": "{} {}".format(name, folder),
-                    "subtitle": "Open {} using {} profile.".format(title, browser_profile),
-                    "title": browser_profile,
-                })
+            profiles.append({
+                "icon": {
+                    "path": "icons/{}".format(icon)
+                },
+                "arg": "{} {}".format(name, folder),
+                "subtitle": "Open {} using {} profile.".format(title, browser_profile),
+                "title": browser_profile,
+            })
 
     return profiles


### PR DESCRIPTION
In modern Chrome, each profile's `Preferences` file contains the generic name "Your Chrome" rather than the actual profile name. This causes all Chromium-based profiles to appear with the same unhelpful label.

This fix reads profile names from the browser's `Local State` file (`profile.info_cache`) instead, which contains the correct user-facing profile names (e.g. "Personal", "Work"). It falls back to `shortcut_name`, `gaia_name`, or the folder name if `name` is unavailable.